### PR TITLE
feat: add ArrayPool-style UnboundedPool

### DIFF
--- a/docs/notes/hold-timeout-reclaims-the-slot-not-the-item.md
+++ b/docs/notes/hold-timeout-reclaims-the-slot-not-the-item.md
@@ -1,0 +1,52 @@
+---
+title: Hold-timeout reclaims a capacity slot, not the leased item
+summary: A bounded-pool hold-timeout breaks lease-starvation deadlock by reclaiming one unit of capacity (allocated = idle + leased, capped at maxSize) after a caller holds an item too long. The item itself stays in the caller's hands and is never repatriated; a slow return whose slot was already reclaimed is dropped, not re-pooled. Requires per-lease tracking and exactly-once slot accounting.
+tags: [pool, concurrency, design, note, decision]
+created: 2026-06-15
+document.status: proposed
+---
+
+# Hold-timeout reclaims a capacity slot, not the leased item
+
+A bounded-pool hold-timeout reclaims one unit of capacity after a caller holds an item past a deadline, so the pool heals from callers that never return. It reclaims the slot, never the item.
+
+## the deadlock it solves (observation)
+
+The bounded pool caps `allocated = idle + leased` at `maxSize` (a permit per leased item; see [[docs/notes/semaphoreslim-replaces-pool-lease-rendezvous.md]]). When every slot is leased and callers never return — a crash, a bug, an unbounded hold — `LeaseAsync` can neither hand out an idle item nor create a new one. The pool is permanently starved.
+
+## the model (proposal)
+
+The tracked quantity is `allocated = idle + leased`, capped at `maxSize`. The hold-timeout reclaims one unit of that capacity — a slot — not the item.
+
+- You cannot repatriate the item; it is in the caller's hands. The pool makes no attempt to reclaim, reuse, or dispose it from the timer.
+- Reclaiming the slot decrements `leased`, which frees capacity, which lets the next `LeaseAsync` create a fresh item instead of waiting forever.
+- The timed-out item leaves the books entirely — neither idle nor counted-leased. It is abandoned in the caller's hands.
+
+In today's code the semaphore's permit count is the capacity counter (`ActiveLeases = maxSize - gate.CurrentCount`), so "decrement leased" and "release one permit" are the same operation. The contract is a slot reclaim; the permit is the implementation.
+
+## naming (decision)
+
+This is not the existing `LeaseTimeout`, which is the acquire timeout — how long a caller waits in the queue to get an item. The new field is a hold timeout — how long a caller may keep an item before its slot is reclaimed. Distinct names: `LeaseTimeout` for acquire, `MaxLeaseDuration` (or `AbandonedLeaseTimeout`) for hold. Conflating them is the main readability trap.
+
+## exactly-once: a slot is freed once (inference)
+
+The correctness invariant: a slot is freed exactly once, by either the hold-timer or the caller's return, never both. Two releasers now exist for one lease, so each handed-out lease needs an `Interlocked` flag deciding the winner.
+
+- Return wins the flag — normal path: enqueue idle, free the slot, cancel the timer.
+- Timer wins the flag — free the slot, mark the lease abandoned. The timer cannot touch the item.
+- Slow return after the timer won — the slot already belongs to someone else, so the return must not free capacity again and must not re-pool the item. It disposes the item and walks away. This is the bounded analog of the unbounded pool's drop-when-full.
+
+Freeing twice would read `allocated` one too low and let the pool create an extra live item past `maxSize`.
+
+## what it forces into the bounded pool (inference)
+
+The pool today keeps zero state about leased items — the gate counts them, the items live in callers' hands. The hold-timeout requires:
+
+1. Per-lease tracking: a reference-keyed `ConcurrentDictionary<TPoolItem, LeaseSlot>` (an item is leased to one caller, so identity is a safe key) plus an `ITimer` per active lease via `TimeProvider.CreateTimer` for deterministic tests. This is the same per-item lease-identity tracking that finding I9 (double/foreign release) needs — see [[docs/notes/pool{t}.findings.md]].
+2. `Dispose` stops every outstanding timer, or a timer fires post-disposal and frees a slot on a disposed semaphore — an unobserved background exception.
+3. `ItemsAllocated` softens from exact to approximate: a reclaimed-but-not-yet-returned item is alive but off the books, so the count undercounts true live items. Document it; add a reclaimed/abandoned counter so the gap is observable.
+4. Zero cost when off: all of it lights up only when the hold timeout is finite. Default infinite means no dict, no timers, today's exact behavior.
+
+## sequencing (decision)
+
+This feature adds to the bounded pool, which cuts against the goal of simplifying it. Build it last: ship the unbounded pool first, extract the shared item-store, then add slot-reclaim on the cleaned-up base where the dict-of-active-leases has a natural home.

--- a/src/Pool/ServiceCollections/UnboundedPoolServiceCollectionExtensions.cs
+++ b/src/Pool/ServiceCollections/UnboundedPoolServiceCollectionExtensions.cs
@@ -1,0 +1,295 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Pool.DefaultStrategies;
+using Pool.Metrics;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace Pool;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+
+/// <summary>
+/// IServiceCollection extensions for registering <see cref="UnboundedPool{TPoolItem}"/>, its factory,
+/// and its ready check. Parallels <see cref="ServiceCollectionExtensions"/> and
+/// <see cref="NamedPoolServiceCollectionExtensions"/>, but binds <see cref="UnboundedPoolOptions"/>.
+/// </summary>
+public static class UnboundedPoolServiceCollectionExtensions
+{
+    /// <summary>
+    /// AddUnboundedPool registers <see cref="IPool{TPoolItem}"/> backed by <see cref="UnboundedPool{TPoolItem}"/>.
+    /// Provide a configure action to specify whether or not to register default
+    /// <see cref="IPreparationStrategy{TPoolItem}"/> and <see cref="IItemFactory{TPoolItem}"/> implementations.
+    /// </summary>
+    /// <typeparam name="TPoolItem">The type of item contained by the pool.</typeparam>
+    /// <param name="services"><see cref="IServiceCollection"/></param>
+    /// <param name="configuration"><see cref="IConfiguration"/></param>
+    /// <param name="configureOptions"><see cref="Action{T}"/> and <see cref="UnboundedPoolOptions"/></param>
+    /// <returns><see cref="IServiceCollection"/></returns>
+    [RequiresDynamicCode("dynamic binding of strongly typed options might require dynamic code")]
+    [RequiresUnreferencedCode("dynamic binding of strongly typed options might require unreferenced code")]
+    public static IServiceCollection AddUnboundedPool<TPoolItem>(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        Action<UnboundedPoolOptions>? configureOptions = null)
+        where TPoolItem : class
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        // eager bind drives the registration-time UseDefault* decisions below
+        var options = configuration
+            .GetSection(nameof(UnboundedPoolOptions))
+            .Get<UnboundedPoolOptions>()
+            ?? new UnboundedPoolOptions();
+
+        configureOptions?.Invoke(options);
+
+        // the validated options pipeline is the runtime source the pool consumes:
+        // ValidateDataAnnotations enforces the [Range] constraints, ValidateOnStart fails fast at host startup
+        var optionsBuilder = services
+            .AddOptions<UnboundedPoolOptions>()
+            .Bind(configuration.GetSection(nameof(UnboundedPoolOptions)));
+        if (configureOptions is not null)
+        {
+            _ = optionsBuilder.Configure(configureOptions);
+        }
+
+        _ = optionsBuilder
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        _ = services
+            .AddDefaultPreparationStrategy<TPoolItem>(options)
+            .AddDefaultItemFactory<TPoolItem>(options)
+            .AddDefaultUnboundedPoolMetrics<TPoolItem>();
+        services.TryAddSingleton(static sp => sp.GetRequiredService<IOptions<UnboundedPoolOptions>>().Value);
+        services.TryAddSingleton<IPool<TPoolItem>, UnboundedPool<TPoolItem>>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds a named <see cref="IPool{TPoolItem}"/> backed by <see cref="UnboundedPool{TPoolItem}"/>
+    /// and registers a typed client that uses this pool.
+    /// </summary>
+    /// <typeparam name="TPoolItem">The type of item contained by the pool.</typeparam>
+    /// <typeparam name="TClient">The type of the typed client that has the pool injected into its constructor.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <param name="configuration">The <see cref="IConfiguration"/> to bind options from.</param>
+    /// <param name="configureOptions">The action to configure the <see cref="UnboundedPoolOptions"/>.</param>
+    /// <param name="configureClient">The action to configure the client.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    [RequiresDynamicCode("dynamic binding of strongly typed options might require dynamic code")]
+    [RequiresUnreferencedCode("dynamic binding of strongly typed options might require unreferenced code")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "matches the bounded named-pool registration path")]
+    public static IServiceCollection AddUnboundedPool<TPoolItem, TClient>(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        Action<UnboundedPoolOptions>? configureOptions = null,
+        Action<TClient>? configureClient = null)
+        where TPoolItem : class
+        where TClient : class
+    {
+        var name = typeof(TClient).FullName ?? typeof(TClient).Name;
+        services
+            .AddNamedUnboundedPool<TPoolItem>(name, configuration, configureOptions)
+            .TryAddTransient(serviceProvider =>
+            {
+                var poolFactory = serviceProvider.GetRequiredService<IPoolFactory<TPoolItem>>();
+                var serviceKey = ServiceKey.Create<TPoolItem>(name);
+                var pool = poolFactory.CreatePool(serviceKey);
+                var client = ActivatorUtilities.CreateInstance<TClient>(serviceProvider, pool);
+                configureClient?.Invoke(client);
+                return client;
+            });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds a named <see cref="IPool{TPoolItem}"/> backed by <see cref="UnboundedPool{TPoolItem}"/>.
+    /// </summary>
+    /// <typeparam name="TPoolItem">The type of item contained by the pool.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <param name="name">The name of the pool.</param>
+    /// <param name="configuration">The <see cref="IConfiguration"/> to bind options from.</param>
+    /// <param name="configureOptions">The action to configure the <see cref="UnboundedPoolOptions"/>.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    [RequiresDynamicCode("dynamic binding of strongly typed options might require dynamic code")]
+    [RequiresUnreferencedCode("dynamic binding of strongly typed options might require unreferenced code")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "matches the bounded named-pool registration path")]
+    public static IServiceCollection AddNamedUnboundedPool<TPoolItem>(
+        this IServiceCollection services,
+        string name,
+        IConfiguration configuration,
+        Action<UnboundedPoolOptions>? configureOptions = null)
+        where TPoolItem : class
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name, nameof(name));
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var serviceKey = ServiceKey.Create<TPoolItem>(name);
+
+        // eager bind drives the registration-time UseDefault* decisions below
+        var options = configuration.GetSection($"{serviceKey}_{nameof(UnboundedPoolOptions)}").Get<UnboundedPoolOptions>()
+            ?? configuration.GetSection(nameof(UnboundedPoolOptions)).Get<UnboundedPoolOptions>()
+            ?? new UnboundedPoolOptions();
+
+        configureOptions?.Invoke(options);
+
+        // named, validated options pipeline keyed by serviceKey; the pool resolves it via IOptionsMonitor.
+        // bind the general section first, then let the pool-specific section override it per-property.
+        var optionsBuilder = services
+            .AddOptions<UnboundedPoolOptions>(serviceKey)
+            .Bind(configuration.GetSection(nameof(UnboundedPoolOptions)))
+            .Bind(configuration.GetSection($"{serviceKey}_{nameof(UnboundedPoolOptions)}"));
+        if (configureOptions is not null)
+        {
+            _ = optionsBuilder.Configure(configureOptions);
+        }
+
+        _ = optionsBuilder
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        _ = services
+            .AddPoolFactory<TPoolItem>()
+            // the keyed UnboundedPoolOptions stays resolvable, but now delegates to the validated
+            // named-options pipeline above (single source of truth) instead of a raw, unvalidated instance
+            .AddKeyedSingleton(serviceKey, static (serviceProvider, key) =>
+                serviceProvider.GetRequiredService<IOptionsMonitor<UnboundedPoolOptions>>().Get((string)key!))
+            .AddDefaultPreparationStrategy<TPoolItem>(options, serviceKey)
+            .AddDefaultItemFactory<TPoolItem>(options, serviceKey)
+            .AddDefaultUnboundedPoolMetrics<TPoolItem>(name)
+            .AddKeyedSingleton<IPool<TPoolItem>>(serviceKey, (services, serviceKey) =>
+            {
+                var itemFactory =
+                    services.GetKeyedService<IItemFactory<TPoolItem>>(serviceKey)
+                    ?? services.GetRequiredService<IItemFactory<TPoolItem>>();
+
+                var logger =
+                    services.GetKeyedService<ILogger<UnboundedPool<TPoolItem>>>(serviceKey)
+                    ?? services.GetRequiredService<ILogger<UnboundedPool<TPoolItem>>>();
+
+                var metrics =
+                    services.GetRequiredKeyedService<IPoolMetrics>(serviceKey);
+
+                var preparationStrategy =
+                    services.GetKeyedService<IPreparationStrategy<TPoolItem>>(serviceKey)
+                    ?? services.GetService<IPreparationStrategy<TPoolItem>>();
+
+                var options =
+                    services.GetRequiredKeyedService<UnboundedPoolOptions>(serviceKey);
+
+                return new UnboundedPool<TPoolItem>(itemFactory, logger, metrics, preparationStrategy, options);
+            });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="IPoolMetrics"/> with the default implementation, named for the unbounded pool.
+    /// </summary>
+    /// <typeparam name="TPoolItem">The type of item contained by the pool.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    [RequiresDynamicCode("dynamic binding of strongly typed options might require dynamic code")]
+    [RequiresUnreferencedCode("dynamic binding of strongly typed options might require unreferenced code")]
+    public static IServiceCollection AddDefaultUnboundedPoolMetrics<TPoolItem>(this IServiceCollection services)
+        where TPoolItem : class
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services
+            .AddMetrics()
+            .TryAddSingleton<IPoolMetrics>((services) =>
+            new DefaultPoolMetrics(
+                UnboundedPool<TPoolItem>.PoolName,
+                services.GetRequiredService<IMeterFactory>(),
+                services.GetRequiredService<ILogger<DefaultPoolMetrics>>()));
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="IPoolMetrics"/> with the default implementation, named for the unbounded pool.
+    /// </summary>
+    /// <typeparam name="TPoolItem">The type of item contained by the pool.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <param name="name">The name of the pool.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    [RequiresDynamicCode("dynamic binding of strongly typed options might require dynamic code")]
+    [RequiresUnreferencedCode("dynamic binding of strongly typed options might require unreferenced code")]
+    public static IServiceCollection AddDefaultUnboundedPoolMetrics<TPoolItem>(
+        this IServiceCollection services,
+        string name)
+        where TPoolItem : class
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name, nameof(name));
+
+        var serviceKey = ServiceKey.Create<TPoolItem>(name);
+        services
+            .AddMetrics()
+            .TryAddKeyedSingleton<IPoolMetrics>(serviceKey,
+            (services, serviceKey) =>
+            new DefaultPoolMetrics(
+                $"{name}.{UnboundedPool<TPoolItem>.PoolName}",
+                services.GetRequiredService<IMeterFactory>(),
+                services.GetRequiredService<ILogger<DefaultPoolMetrics>>()));
+        return services;
+    }
+
+    private static IServiceCollection AddDefaultPreparationStrategy<TPoolItem>(this IServiceCollection services, UnboundedPoolOptions options)
+        where TPoolItem : class
+    {
+        if (options.UseDefaultPreparationStrategy)
+        {
+            services.TryAddSingleton<IPreparationStrategy<TPoolItem>, DefaultPreparationStrategy<TPoolItem>>();
+        }
+
+        return services;
+    }
+
+    private static IServiceCollection AddDefaultItemFactory<TPoolItem>(this IServiceCollection services, UnboundedPoolOptions options)
+        where TPoolItem : class
+    {
+        if (options.UseDefaultFactory)
+        {
+            services.TryAddSingleton<IItemFactory<TPoolItem>, DefaultItemFactory<TPoolItem>>();
+        }
+
+        return services;
+    }
+
+    private static IServiceCollection AddDefaultPreparationStrategy<TPoolItem>(
+        this IServiceCollection services,
+        UnboundedPoolOptions options,
+        string serviceKey)
+        where TPoolItem : class
+    {
+        if (options.UseDefaultPreparationStrategy)
+        {
+            services.TryAddKeyedSingleton<IPreparationStrategy<TPoolItem>, DefaultPreparationStrategy<TPoolItem>>(serviceKey);
+        }
+
+        return services;
+    }
+
+    private static IServiceCollection AddDefaultItemFactory<TPoolItem>(
+        this IServiceCollection services,
+        UnboundedPoolOptions options,
+        string serviceKey)
+        where TPoolItem : class
+    {
+        if (options.UseDefaultFactory)
+        {
+            services.TryAddKeyedSingleton<IItemFactory<TPoolItem>, DefaultItemFactory<TPoolItem>>(serviceKey);
+        }
+
+        return services;
+    }
+}

--- a/src/Pool/UnboundedPoolOptions.cs
+++ b/src/Pool/UnboundedPoolOptions.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Pool;
+
+/// <summary>
+/// Options for configuring an <see cref="UnboundedPool{TPoolItem}"/>.
+/// </summary>
+/// <remarks>
+/// The unbounded pool rents without limit and treats release as an optional optimization, so it
+/// honors none of the bounded pool's capacity controls: there is no MaxSize (rent never blocks) and
+/// no LeaseTimeout (there is nothing to wait for). The only cap is on <em>retention</em>:
+/// <see cref="MaxIdle"/> bounds how many returned items are kept for reuse.
+/// </remarks>
+public sealed class UnboundedPoolOptions
+{
+    /// <summary>
+    /// MinSize gets or sets the minimum number of idle items to seed the pool with at construction.
+    /// </summary>
+    /// <remarks>Defaults to zero. Must not be negative. Capped by <see cref="MaxIdle"/> when seeding.</remarks>
+    [Range(0, int.MaxValue)]
+    public int MinSize { get; set; }
+
+    /// <summary>
+    /// MaxIdle gets or sets the maximum number of idle items the pool retains for reuse. Returns
+    /// beyond this cap are dropped (and disposed, if the item is <see cref="IDisposable"/>) rather
+    /// than pooled. This bounds memory and server-side load without bounding how many items may be
+    /// leased concurrently.
+    /// </summary>
+    /// <remarks>Defaults to 100. Zero means never retain — every return is dropped (pure allocate-on-lease).</remarks>
+    [Range(0, int.MaxValue)]
+    public int MaxIdle { get; set; } = 100;
+
+    /// <summary>
+    /// PreparationTimeout gets or sets the timeout to wait for the ready check and attempt to make ready a pool item before completing the lease request.
+    /// </summary>
+    /// <remarks>Defaults to Timeout.InfiniteTimeSpan</remarks>
+    public TimeSpan PreparationTimeout { get; set; } = Timeout.InfiniteTimeSpan;
+
+    /// <summary>
+    /// IdleTimeout gets or sets the timeout for an item to be idle before it is dropped from the pool. Expired idle items are discarded (and disposed) when encountered on lease.
+    /// </summary>
+    /// <remarks>Defaults to Timeout.InfiniteTimeSpan</remarks>
+    public TimeSpan IdleTimeout { get; set; } = Timeout.InfiniteTimeSpan;
+
+    /// <summary>
+    /// Set to true to register the default <see cref="IPreparationStrategy{TPoolItem}"/> implementation.
+    /// </summary>
+    /// <remarks>Defaults to false.</remarks>
+    public bool UseDefaultPreparationStrategy { get; set; }
+
+    /// <summary>
+    /// Set to true to register the default <see cref="IItemFactory{TPoolItem}"/> implementation.
+    /// </summary>
+    /// <remarks>Defaults to false.</remarks>
+    public bool UseDefaultFactory { get; set; }
+}

--- a/src/Pool/UnboundedPool{TPoolItem}.cs
+++ b/src/Pool/UnboundedPool{TPoolItem}.cs
@@ -1,0 +1,398 @@
+using Microsoft.Extensions.Logging;
+using Pool.Metrics;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Pool;
+
+/// <summary>
+/// An unbounded pool modeled on <see cref="System.Buffers.ArrayPool{T}"/>: <see cref="LeaseAsync()"/>
+/// never waits — it returns an idle item or creates one on demand — and <see cref="Release(TPoolItem)"/>
+/// is an optional optimization that donates an item back for reuse. A lease transfers ownership of the
+/// item to the caller; if the caller never releases it, the item is simply not reused (and, if it is
+/// <see cref="IDisposable"/>, disposing it becomes the caller's responsibility, exactly as for any
+/// object the caller owns). The pool only ever disposes the idle items it still holds — on a capped
+/// return that overflows, on idle-timeout eviction, on <see cref="Clear"/>, and on <see cref="Dispose"/>.
+/// </summary>
+/// <remarks>
+/// Contrast with <see cref="Pool{TPoolItem}"/>, which is a <em>borrow</em>: the bounded pool retains
+/// title and a lease must be returned. Here a lease is an <em>ownership transfer</em>, which is what
+/// makes optional release safe even for disposable items.
+/// </remarks>
+/// <typeparam name="TPoolItem">the reference type managed by the pool.</typeparam>
+public sealed class UnboundedPool<TPoolItem>
+    : IPool<TPoolItem>
+    where TPoolItem : class
+{
+    private readonly record struct PoolItem(
+        DateTimeOffset IdleSince,
+        TPoolItem Item)
+    {
+        // the clock read is the caller's: the pool passes timeProvider.GetUtcNow() so the struct
+        // stays clock-free and idle expiry is deterministically testable (a FakeTimeProvider drives it)
+        public static PoolItem Create(DateTimeOffset now, TPoolItem item) => new(now, item);
+    }
+
+    private static readonly bool IsPoolItemDisposable = typeof(TPoolItem).GetInterface(nameof(IDisposable), true) is not null;
+
+    // idle (available) items waiting to be leased
+    private readonly ConcurrentQueue<PoolItem> pool;
+
+    // the retention accountant: reserved before enqueue and released on dequeue/drop, so the MaxIdle
+    // cap is enforced without reading ConcurrentQueue.Count on the Release hot path. It may briefly
+    // skew from pool.Count inside an enqueue/dequeue, so it gates the cap; pool.Count reports availability.
+    private int idleCount;
+
+    // outstanding leases: handed-out minus returned. an item a caller leased and never released stays
+    // counted (it genuinely is still out there), so this is an honest gauge for an unbounded pool.
+    private int activeLeases;
+
+    private readonly int maxIdle;
+    private readonly int initialSize;
+    private readonly bool isPreparationRequired;
+    private readonly IItemFactory<TPoolItem> itemFactory;
+    private readonly ILogger<UnboundedPool<TPoolItem>> logger;
+    private readonly IPreparationStrategy<TPoolItem>? preparationStrategy;
+    private readonly TimeSpan idleTimeout;
+    private readonly TimeSpan preparationTimeout;
+    private bool disposed;
+    private readonly IPoolMetrics metrics;
+    // handles for the observable-instrument registrations; disposed on pool disposal so the
+    // instruments stop reporting and no longer root this pool via the (longer-lived) meter.
+    private readonly IDisposable[] observerRegistrations;
+    private readonly TimeProvider timeProvider;
+
+    /// <summary>
+    /// PoolName is the name of the pool in the form $"{typeof(TPoolItem).Name}.UnboundedPool"
+    /// </summary>
+    public static readonly string PoolName = $"{typeof(TPoolItem).Name}.UnboundedPool";
+
+    /// <summary>
+    /// ctor
+    /// </summary>
+    /// <param name="itemFactory"><see cref="IItemFactory{TPoolItem}"/></param>
+    /// <param name="logger"></param>
+    /// <param name="metrics"><see cref="IPoolMetrics"/></param>
+    /// <param name="options"><see cref="UnboundedPoolOptions"/></param>
+    /// <param name="timeProvider">clock for idle-timeout tracking; defaults to <see cref="TimeProvider.System"/></param>
+    public UnboundedPool(
+        IItemFactory<TPoolItem> itemFactory,
+        ILogger<UnboundedPool<TPoolItem>> logger,
+        IPoolMetrics metrics,
+        UnboundedPoolOptions options,
+        TimeProvider? timeProvider = null)
+        : this(itemFactory, logger, metrics, null, options, timeProvider)
+    { }
+
+    /// <summary>
+    /// ctor
+    /// </summary>
+    /// <param name="itemFactory"><see cref="IItemFactory{TPoolItem}"/></param>
+    /// <param name="logger"></param>
+    /// <param name="metrics"><see cref="IPoolMetrics"/></param>
+    /// <param name="preparationStrategy"><see cref="IPreparationStrategy{TPoolItem}"/></param>
+    /// <param name="options"><see cref="UnboundedPoolOptions"/></param>
+    /// <param name="timeProvider">clock for idle-timeout tracking; defaults to <see cref="TimeProvider.System"/></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public UnboundedPool(
+        IItemFactory<TPoolItem> itemFactory,
+        ILogger<UnboundedPool<TPoolItem>> logger,
+        IPoolMetrics metrics,
+        IPreparationStrategy<TPoolItem>? preparationStrategy,
+        UnboundedPoolOptions options,
+        TimeProvider? timeProvider = null)
+    {
+        ArgumentNullException.ThrowIfNull(itemFactory);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(metrics);
+        ArgumentNullException.ThrowIfNull(options);
+        // backstop for every construction path (direct new(...) bypasses the options pipeline)
+        ArgumentOutOfRangeException.ThrowIfNegative(options.MinSize);
+        ArgumentOutOfRangeException.ThrowIfNegative(options.MaxIdle);
+
+        this.itemFactory = itemFactory;
+        this.logger = logger;
+        this.metrics = metrics;
+        this.timeProvider = timeProvider ?? TimeProvider.System;
+
+        isPreparationRequired = preparationStrategy is not null;
+        this.preparationStrategy = preparationStrategy;
+        maxIdle = options.MaxIdle;
+        // never seed past the retention cap, otherwise the pool would start over its own idle limit
+        initialSize = Math.Min(options.MinSize, maxIdle);
+
+        idleTimeout = options.IdleTimeout;
+        preparationTimeout = options.PreparationTimeout;
+
+        // seed the idle pool first so a factory failure mid-seed disposes what it already created
+        // and leaves the pool with consistent state
+        pool = new();
+        try
+        {
+            foreach (var item in CreateItems(initialSize))
+            {
+                pool.Enqueue(PoolItem.Create(this.timeProvider.GetUtcNow(), item));
+            }
+        }
+        catch
+        {
+            DrainPoolAndDisposeItems();
+            throw;
+        }
+
+        idleCount = pool.Count;
+
+        observerRegistrations =
+        [
+            this.metrics.RegisterItemsAllocatedObserver(() => ItemsAllocated),
+            this.metrics.RegisterItemsAvailableObserver(() => ItemsAvailable),
+            this.metrics.RegisterActiveLeasesObserver(() => ActiveLeases),
+            this.metrics.RegisterQueuedLeasesObserver(() => QueuedLeases),
+            this.metrics.RegisterUtilizationRateObserver(() => ItemsAllocated == 0 ? 0 : (double)ActiveLeases / ItemsAllocated),
+        ];
+
+        logger.LogInformation("{PoolName} created with {@Options}", PoolName, options);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>derived: outstanding leases plus idle (available).</remarks>
+    public int ItemsAllocated => ActiveLeases + ItemsAvailable;
+
+    /// <inheritdoc/>
+    public int ItemsAvailable => pool.Count;
+
+    /// <inheritdoc/>
+    /// <remarks>outstanding leases: items handed out and not yet returned, including any a caller dropped without releasing.</remarks>
+    public int ActiveLeases => Volatile.Read(ref activeLeases);
+
+    /// <inheritdoc/>
+    /// <remarks>always zero: an unbounded lease never waits, so nothing is ever queued.</remarks>
+    public int QueuedLeases => 0;
+
+    /// <inheritdoc/>
+    public string Name => PoolName;
+
+    /// <inheritdoc/>
+    public ValueTask<TPoolItem> LeaseAsync() => LeaseAsync(CancellationToken.None);
+
+    /// <inheritdoc/>
+    /// <remarks>never waits for capacity: returns an idle item or creates one. cancellation is honored up front and during preparation.</remarks>
+    public async ValueTask<TPoolItem> LeaseAsync(CancellationToken cancellationToken)
+    {
+        using var logscope = logger.BeginScope("{PoolName}.{Method}:{Id}", PoolName, nameof(LeaseAsync), Guid.NewGuid());
+
+        var startTimestamp = timeProvider.GetTimestamp();
+        try
+        {
+            ThrowIfDisposed();
+            // honor an already-cancelled token before acquiring, so there is nothing to unwind
+            cancellationToken.ThrowIfCancellationRequested();
+
+            logger.LogDebug("starting lease request, pool state: {ItemsAllocated} allocated, {ItemsAvailable} available",
+                ItemsAllocated, ItemsAvailable);
+
+            // no gate: an item is always available immediately (idle or freshly created)
+            var item = TryAcquireItem();
+            // record the lease wait (acquire only — never a queue wait here) before preparation, so the
+            // metric excludes prep time, which RecordPreparationTime already captures separately
+            RecordLeaseWaitTime(startTimestamp);
+            var prepared = await EnsurePreparedAsync(item, cancellationToken);
+
+            // count the lease only once it is successfully handed to the caller. a preparation failure
+            // disposed the item inside EnsurePreparedAsync and never reached here, so activeLeases stays
+            // correct without a compensating decrement.
+            _ = Interlocked.Increment(ref activeLeases);
+            return prepared;
+        }
+        catch (Exception ex)
+        {
+            RecordLeaseException(startTimestamp, ex);
+            throw;
+        }
+    }
+
+    private void RecordLeaseException(long startTimestamp, Exception ex)
+    {
+        var elapsed = timeProvider.GetElapsedTime(startTimestamp);
+        logger.LogError(ex, "lease failure after {ElapsedMs}ms", elapsed.TotalMilliseconds);
+        metrics.RecordLeaseException(ex);
+    }
+
+    private void RecordLeaseWaitTime(long startTimestamp)
+    {
+        var elapsed = timeProvider.GetElapsedTime(startTimestamp);
+        logger.LogDebug("lease completed in {ElapsedMs}ms", elapsed.TotalMilliseconds);
+        metrics.RecordLeaseWaitTime(elapsed);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// optional: the caller owns the item once leased. releasing donates it back for reuse if the pool
+    /// is under its idle cap; otherwise the item is dropped (and disposed, if disposable).
+    /// </remarks>
+    public void Release(TPoolItem item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ThrowIfDisposed();
+        using var logscope = logger.BeginScope("{PoolName}.{Method}:{Id}", PoolName, nameof(Release), Guid.NewGuid());
+
+        // the caller handed the item back, so it is no longer outstanding regardless of whether we retain it
+        _ = Interlocked.Decrement(ref activeLeases);
+
+        // optimistically reserve an idle slot; if that would exceed the cap, undo and drop the item.
+        // reserving before the enqueue keeps the cap honest under concurrent returns (no overshoot).
+        if (Interlocked.Increment(ref idleCount) <= maxIdle)
+        {
+            pool.Enqueue(PoolItem.Create(timeProvider.GetUtcNow(), item));
+            logger.LogDebug("returned item to the pool");
+            return;
+        }
+
+        _ = Interlocked.Decrement(ref idleCount);
+        logger.LogDebug("idle cap {MaxIdle} reached, dropping returned item", maxIdle);
+        DisposeItem(item);
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        using var logscope = logger.BeginScope("{PoolName}.{Method}:{Id}", PoolName, nameof(Clear), Guid.NewGuid());
+
+        ThrowIfDisposed();
+
+        // dispose every currently-idle item; items leased out are unaffected (the caller owns them)
+        DrainPoolAndDisposeItems();
+
+        // refill idle up to MinSize (already capped by MaxIdle in initialSize)
+        for (var i = 0; i < initialSize; i++)
+        {
+            pool.Enqueue(PoolItem.Create(timeProvider.GetUtcNow(), itemFactory.CreateItem()));
+        }
+
+        _ = Interlocked.Exchange(ref idleCount, pool.Count);
+    }
+
+    private IEnumerable<TPoolItem> CreateItems(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return itemFactory.CreateItem();
+        }
+    }
+
+    /// <remarks>returns a valid idle item if one exists, dropping any that have exceeded the idle timeout, otherwise creates a fresh one.</remarks>
+    private TPoolItem TryAcquireItem()
+    {
+        // one clock read drives the whole dequeue scan, so every candidate is judged against the same now
+        var now = timeProvider.GetUtcNow();
+        while (pool.TryDequeue(out var pooled))
+        {
+            _ = Interlocked.Decrement(ref idleCount);
+            if (IdleTimeIsNotExceeded(idleTimeout, pooled, now))
+            {
+                logger.LogDebug("TryAcquireItem {AcquisitionMethod}", "dequeued");
+                return pooled.Item;
+            }
+
+            logger.LogInformation("{PoolName}.{MethodName} removing expired item, {IdleTimeMs}ms exceeded limit: {IdleTimeoutMs}ms",
+                PoolName, nameof(TryAcquireItem), (now - pooled.IdleSince).TotalMilliseconds, idleTimeout.TotalMilliseconds);
+            DisposeItem(pooled.Item);
+        }
+
+        logger.LogDebug("TryAcquireItem {AcquisitionMethod}", "created");
+        return itemFactory.CreateItem();
+    }
+
+    private static bool IdleTimeIsNotExceeded(TimeSpan idleTimeout, PoolItem item, DateTimeOffset now) =>
+        idleTimeout == Timeout.InfiniteTimeSpan || now - item.IdleSince < idleTimeout;
+
+    [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP007:Don't dispose injected", Justification = "it's all private to pool")]
+    private static void DisposeItem(TPoolItem item)
+    {
+        if (IsPoolItemDisposable)
+        {
+            // IsPoolItemDisposable guarantees TPoolItem implements IDisposable, so the cast is safe
+            ((IDisposable)item).Dispose();
+        }
+    }
+
+    /// <remarks>
+    /// removes and disposes the pool item if preparation fails
+    /// </remarks>
+    private async ValueTask<TPoolItem> EnsurePreparedAsync(
+        TPoolItem item,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation("{PoolName}.{MethodName} ensuring item preparation, required: {IsPreparationRequired}",
+            PoolName, nameof(EnsurePreparedAsync), isPreparationRequired);
+
+        if (!isPreparationRequired)
+        {
+            return item;
+        }
+
+        try
+        {
+            var startTimestamp = timeProvider.GetTimestamp();
+            using var timeoutCts = new CancellationTokenSource(preparationTimeout, timeProvider);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
+            cancellationToken = linkedCts.Token;
+
+            if (await preparationStrategy!.IsReadyAsync(item, cancellationToken))
+            {
+                logger.LogDebug("item already prepared, skipping preparation step");
+                return item;
+            }
+
+            logger.LogDebug("preparing item with timeout: {PreparationTimeoutMs}ms", preparationTimeout.TotalMilliseconds);
+            await preparationStrategy.PrepareAsync(item, cancellationToken);
+
+            var elapsed = timeProvider.GetElapsedTime(startTimestamp);
+            metrics.RecordPreparationTime(elapsed);
+            logger.LogDebug("item preparation completed in {ElapsedMs}ms", elapsed.TotalMilliseconds);
+            return item;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "preparation failure");
+            // preparation failed, so the item is in an indeterminate state (e.g. a dropped socket).
+            // discard and dispose it rather than handing it to the caller. the lease was never counted
+            // (activeLeases is incremented only on success), and the caller is expected to retry.
+            DisposeItem(item);
+            metrics.RecordPreparationException(ex);
+            throw;
+        }
+    }
+
+    private void DrainPoolAndDisposeItems()
+    {
+        while (pool.TryDequeue(out var item))
+        {
+            _ = Interlocked.Decrement(ref idleCount);
+            DisposeItem(item.Item);
+        }
+    }
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(disposed, nameof(UnboundedPool<>));
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        // sever the observable instruments first so a concurrent metrics collection cannot read
+        // pool state mid-teardown, and so the meter no longer roots this disposed pool
+        foreach (var registration in observerRegistrations)
+        {
+            registration?.Dispose();
+        }
+
+        // dispose the idle items the pool still owns; leased-out items belong to their callers
+        DrainPoolAndDisposeItems();
+    }
+}

--- a/tests/Pool.Tests/UnboundedPoolServiceCollectionTests.cs
+++ b/tests/Pool.Tests/UnboundedPoolServiceCollectionTests.cs
@@ -1,0 +1,309 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Pool.Metrics;
+using Pool.Tests.Fakes;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Pool.Tests;
+
+public sealed class UnboundedPoolServiceCollectionTests
+{
+    private sealed class PoolItem;
+
+    private sealed class PoolClient(IPool<PoolItem> pool)
+    {
+        public IPool<PoolItem> Pool { get; } = pool ?? throw new ArgumentNullException(nameof(pool));
+        public bool Configured { get; set; }
+    }
+
+    private static IConfiguration Configuration(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    private static IConfiguration EmptyConfiguration() => Configuration([]);
+
+    // --- AddUnboundedPool<TPoolItem> ---
+
+    [Fact]
+    public void AddUnboundedPool_With_Defaults_Resolves_Pool_And_Default_Services()
+    {
+        var configuration = Configuration(new()
+        {
+            ["UnboundedPoolOptions:UseDefaultFactory"] = "true",
+            ["UnboundedPoolOptions:UseDefaultPreparationStrategy"] = "true",
+        });
+
+        using var provider = new ServiceCollection()
+            .AddLogging()
+            .AddScoped<IEcho, Echo>()
+            .AddUnboundedPool<IEcho>(configuration)
+            .BuildServiceProvider();
+
+        var pool = provider.GetRequiredService<IPool<IEcho>>();
+        _ = Assert.IsType<UnboundedPool<IEcho>>(pool);
+        Assert.NotNull(provider.GetRequiredService<IItemFactory<IEcho>>());
+        Assert.NotNull(provider.GetRequiredService<IPreparationStrategy<IEcho>>());
+        Assert.NotNull(provider.GetRequiredService<IPoolMetrics>());
+    }
+
+    [Fact]
+    public void AddUnboundedPool_Without_Defaults_Does_Not_Register_Factory_Or_Strategy()
+    {
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddUnboundedPool<IEcho>(EmptyConfiguration());
+
+        Assert.DoesNotContain(services, d => d.ServiceType == typeof(IItemFactory<IEcho>));
+        Assert.DoesNotContain(services, d => d.ServiceType == typeof(IPreparationStrategy<IEcho>));
+    }
+
+    [Fact]
+    public void AddUnboundedPool_Without_Section_Binds_Defaults()
+    {
+        using var provider = new ServiceCollection()
+            .AddLogging()
+            .AddUnboundedPool<IEcho>(EmptyConfiguration())
+            .BuildServiceProvider();
+
+        Assert.Equal(100, provider.GetRequiredService<UnboundedPoolOptions>().MaxIdle);
+    }
+
+    [Fact]
+    public void AddUnboundedPool_ConfigureOptions_Is_Applied()
+    {
+        using var provider = new ServiceCollection()
+            .AddLogging()
+            .AddUnboundedPool<IEcho>(EmptyConfiguration(), options => options.MaxIdle = 7)
+            .BuildServiceProvider();
+
+        Assert.Equal(7, provider.GetRequiredService<UnboundedPoolOptions>().MaxIdle);
+    }
+
+    [Fact]
+    public void AddUnboundedPool_Negative_MaxIdle_Throws_On_Resolve()
+    {
+        var configuration = Configuration(new() { ["UnboundedPoolOptions:MaxIdle"] = "-1" });
+
+        using var provider = new ServiceCollection()
+            .AddLogging()
+            .AddUnboundedPool<IEcho>(configuration)
+            .BuildServiceProvider();
+
+        _ = Assert.Throws<OptionsValidationException>(provider.GetRequiredService<UnboundedPoolOptions>);
+    }
+
+    [Fact]
+    public void AddUnboundedPool_Negative_MinSize_Throws_On_Resolve()
+    {
+        var configuration = Configuration(new() { ["UnboundedPoolOptions:MinSize"] = "-1" });
+
+        using var provider = new ServiceCollection()
+            .AddLogging()
+            .AddUnboundedPool<IEcho>(configuration)
+            .BuildServiceProvider();
+
+        _ = Assert.Throws<OptionsValidationException>(provider.GetRequiredService<UnboundedPoolOptions>);
+    }
+
+    [Fact]
+    public void AddUnboundedPool_Null_Services_Throws() =>
+        Assert.Throws<ArgumentNullException>(
+            () => ((IServiceCollection)null!).AddUnboundedPool<IEcho>(EmptyConfiguration()));
+
+    [Fact]
+    public void AddUnboundedPool_Null_Configuration_Throws() =>
+        Assert.Throws<ArgumentNullException>(
+            () => new ServiceCollection().AddUnboundedPool<IEcho>(null!));
+
+    // --- AddUnboundedPool<TPoolItem, TClient> (named, with client) ---
+
+    [Fact]
+    public void AddUnboundedPool_With_Client_Registration_Succeeds()
+    {
+        var configuration = Configuration(new()
+        {
+            ["UnboundedPoolOptions:UseDefaultFactory"] = "true",
+            ["UnboundedPoolOptions:UseDefaultPreparationStrategy"] = "true",
+        });
+
+        using var services = new ServiceCollection()
+            .AddLogging()
+            .AddTransient<PoolItem>()
+            .AddUnboundedPool<PoolItem, PoolClient>(configuration)
+            .BuildServiceProvider();
+
+        var client = services.GetRequiredService<PoolClient>();
+        Assert.NotNull(client.Pool);
+        _ = Assert.IsType<UnboundedPool<PoolItem>>(client.Pool);
+    }
+
+    [Fact]
+    public void AddUnboundedPool_With_Client_Runs_ConfigureClient()
+    {
+        using var services = new ServiceCollection()
+            .AddLogging()
+            .AddTransient<PoolItem>()
+            .AddUnboundedPool<PoolItem, PoolClient>(
+                EmptyConfiguration(),
+                configureOptions: options => options.UseDefaultFactory = true,
+                configureClient: client => client.Configured = true)
+            .BuildServiceProvider();
+
+        var client = services.GetRequiredService<PoolClient>();
+        Assert.True(client.Configured);
+    }
+
+    // --- AddNamedUnboundedPool<TPoolItem> ---
+
+    [Fact]
+    public void AddNamedUnboundedPool_ConfigureOptions_Is_Applied()
+    {
+        var serviceKey = ServiceKey.Create<PoolItem>("alpha");
+
+        using var provider = new ServiceCollection()
+            .AddLogging()
+            .AddTransient<PoolItem>()
+            .AddNamedUnboundedPool<PoolItem>("alpha", EmptyConfiguration(), options => options.MaxIdle = 9)
+            .BuildServiceProvider();
+
+        Assert.Equal(9, provider.GetRequiredKeyedService<UnboundedPoolOptions>(serviceKey).MaxIdle);
+    }
+
+    [Fact]
+    public void AddNamedUnboundedPool_PoolSpecific_Section_Overrides_General()
+    {
+        var serviceKey = ServiceKey.Create<PoolItem>("beta");
+        var configuration = Configuration(new()
+        {
+            ["UnboundedPoolOptions:MaxIdle"] = "5",
+            [$"{serviceKey}_UnboundedPoolOptions:MaxIdle"] = "11",
+        });
+
+        using var provider = new ServiceCollection()
+            .AddLogging()
+            .AddTransient<PoolItem>()
+            .AddNamedUnboundedPool<PoolItem>("beta", configuration)
+            .BuildServiceProvider();
+
+        Assert.Equal(11, provider.GetRequiredKeyedService<UnboundedPoolOptions>(serviceKey).MaxIdle);
+    }
+
+    [Fact]
+    public void AddNamedUnboundedPool_Without_Sections_Uses_Defaults()
+    {
+        var serviceKey = ServiceKey.Create<PoolItem>("gamma");
+
+        using var provider = new ServiceCollection()
+            .AddLogging()
+            .AddTransient<PoolItem>()
+            .AddNamedUnboundedPool<PoolItem>("gamma", EmptyConfiguration())
+            .BuildServiceProvider();
+
+        Assert.Equal(100, provider.GetRequiredKeyedService<UnboundedPoolOptions>(serviceKey).MaxIdle);
+    }
+
+    [Fact]
+    [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP001:Dispose created", Justification = "the keyed pool is a singleton owned by the ServiceProvider; it is disposed when the provider is disposed")]
+    public void AddNamedUnboundedPool_With_Defaults_Resolves_Keyed_Pool()
+    {
+        var serviceKey = ServiceKey.Create<IEcho>("zeta");
+        var configuration = Configuration(new()
+        {
+            ["UnboundedPoolOptions:UseDefaultFactory"] = "true",
+            ["UnboundedPoolOptions:UseDefaultPreparationStrategy"] = "true",
+        });
+
+        using var provider = new ServiceCollection()
+            .AddLogging()
+            .AddNamedUnboundedPool<IEcho>("zeta", configuration)
+            .BuildServiceProvider();
+
+        var pool = provider.GetRequiredService<IPoolFactory<IEcho>>().CreatePool(serviceKey);
+        _ = Assert.IsType<UnboundedPool<IEcho>>(pool);
+    }
+
+    [Fact]
+    [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP001:Dispose created", Justification = "the keyed pool is a singleton owned by the ServiceProvider; it is disposed when the provider is disposed")]
+    public void AddNamedUnboundedPool_Falls_Back_To_NonKeyed_Services_When_Defaults_Off()
+    {
+        var serviceKey = ServiceKey.Create<IEcho>("delta");
+
+        using var provider = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IItemFactory<IEcho>, EchoFactory>()
+            .AddSingleton<IPreparationStrategy<IEcho>, EchoPreparationStrategy>()
+            .AddNamedUnboundedPool<IEcho>("delta", EmptyConfiguration())
+            .BuildServiceProvider();
+
+        var pool = provider.GetRequiredService<IPoolFactory<IEcho>>().CreatePool(serviceKey);
+        Assert.NotNull(pool);
+    }
+
+    [Fact]
+    public void AddNamedUnboundedPool_Invalid_Options_Throws_On_Resolve()
+    {
+        var serviceKey = ServiceKey.Create<PoolItem>("epsilon");
+        var configuration = Configuration(new() { ["UnboundedPoolOptions:MaxIdle"] = "-1" });
+
+        using var provider = new ServiceCollection()
+            .AddLogging()
+            .AddTransient<PoolItem>()
+            .AddNamedUnboundedPool<PoolItem>("epsilon", configuration)
+            .BuildServiceProvider();
+
+        _ = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredKeyedService<UnboundedPoolOptions>(serviceKey));
+    }
+
+    [Fact]
+    public void AddNamedUnboundedPool_Null_Services_Throws() =>
+        Assert.Throws<ArgumentNullException>(
+            () => ((IServiceCollection)null!).AddNamedUnboundedPool<PoolItem>("name", EmptyConfiguration()));
+
+    [Fact]
+    public void AddNamedUnboundedPool_Null_Name_Throws() =>
+        Assert.Throws<ArgumentNullException>(
+            () => new ServiceCollection().AddNamedUnboundedPool<PoolItem>(null!, EmptyConfiguration()));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddNamedUnboundedPool_Whitespace_Name_Throws(string name) =>
+        Assert.Throws<ArgumentException>(
+            () => new ServiceCollection().AddNamedUnboundedPool<PoolItem>(name, EmptyConfiguration()));
+
+    [Fact]
+    public void AddNamedUnboundedPool_Null_Configuration_Throws() =>
+        Assert.Throws<ArgumentNullException>(
+            () => new ServiceCollection().AddNamedUnboundedPool<PoolItem>("name", null!));
+
+    // --- AddDefaultUnboundedPoolMetrics ---
+
+    [Fact]
+    public void AddDefaultUnboundedPoolMetrics_Resolves_Metrics()
+    {
+        using var provider = new ServiceCollection()
+            .AddLogging()
+            .AddDefaultUnboundedPoolMetrics<IEcho>()
+            .BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<IPoolMetrics>());
+    }
+
+    [Fact]
+    public void AddDefaultUnboundedPoolMetrics_Null_Services_Throws() =>
+        Assert.Throws<ArgumentNullException>(
+            () => ((IServiceCollection)null!).AddDefaultUnboundedPoolMetrics<IEcho>());
+
+    [Fact]
+    public void AddDefaultUnboundedPoolMetrics_Named_Null_Services_Throws() =>
+        Assert.Throws<ArgumentNullException>(
+            () => ((IServiceCollection)null!).AddDefaultUnboundedPoolMetrics<PoolItem>("name"));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddDefaultUnboundedPoolMetrics_Named_Whitespace_Name_Throws(string name) =>
+        Assert.Throws<ArgumentException>(
+            () => new ServiceCollection().AddDefaultUnboundedPoolMetrics<PoolItem>(name));
+}

--- a/tests/Pool.Tests/UnboundedPoolTests.cs
+++ b/tests/Pool.Tests/UnboundedPoolTests.cs
@@ -325,7 +325,7 @@ public sealed class UnboundedPoolTests
         _ = Assert.Throws<ArgumentNullException>(
             () => new UnboundedPool<IEcho>(new EchoFactory(), Logger, null!, new UnboundedPoolOptions()));
         _ = Assert.Throws<ArgumentNullException>(
-            () => new UnboundedPool<IEcho>(new EchoFactory(), Logger, Metrics, (UnboundedPoolOptions)null!));
+            () => new UnboundedPool<IEcho>(new EchoFactory(), Logger, Metrics, null!));
     }
 
     [Fact]

--- a/tests/Pool.Tests/UnboundedPoolTests.cs
+++ b/tests/Pool.Tests/UnboundedPoolTests.cs
@@ -1,0 +1,422 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Pool.Metrics;
+using Pool.Tests.Fakes;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Pool.Tests;
+
+public sealed class UnboundedPoolTests
+{
+    private static readonly ILoggerFactory LoggerFactory = Microsoft.Extensions.Logging.LoggerFactory.Create(builder =>
+        builder.AddConsole().SetMinimumLevel(LogLevel.Debug));
+
+    private static readonly ILogger<UnboundedPool<IEcho>> Logger = LoggerFactory.CreateLogger<UnboundedPool<IEcho>>();
+
+    private static readonly IPoolMetrics Metrics = new NoopPoolMetrics();
+
+    private static UnboundedPool<IEcho> CreatePool(
+        UnboundedPoolOptions options,
+        IItemFactory<IEcho>? factory = null,
+        IPreparationStrategy<IEcho>? preparationStrategy = null,
+        TimeProvider? timeProvider = null) =>
+        new(factory ?? new EchoFactory(), Logger, Metrics, preparationStrategy, options, timeProvider);
+
+    [Fact]
+    public void Name_Is_TypeName_Dot_UnboundedPool()
+    {
+        using var pool = CreatePool(new UnboundedPoolOptions());
+        Assert.Equal("IEcho.UnboundedPool", pool.Name);
+    }
+
+    [Fact]
+    public void Backlog_Is_Always_Empty()
+    {
+        using var pool = CreatePool(new UnboundedPoolOptions());
+        Assert.Equal(0, pool.QueuedLeases);
+    }
+
+    [Fact]
+    public async Task Lease_Never_Waits_And_Rents_Without_Limit()
+    {
+        // MaxIdle bounds retention, not rent: leasing far past it must still succeed immediately and
+        // hand out distinct items — the defining property of an unbounded pool
+        using var pool = CreatePool(new UnboundedPoolOptions { MinSize = 0, MaxIdle = 2 });
+        var ct = TestContext.Current.CancellationToken;
+
+        var items = new List<IEcho>();
+        for (var i = 0; i < 50; i++)
+        {
+            items.Add(await pool.LeaseAsync(ct));
+        }
+
+        Assert.Equal(50, items.Count);
+        Assert.Equal(50, items.Distinct().Count());
+        Assert.Equal(50, pool.ActiveLeases);
+        Assert.Equal(50, pool.ItemsAllocated);
+        Assert.Equal(0, pool.ItemsAvailable);
+
+        foreach (var item in items)
+        {
+            pool.Release(item);
+        }
+    }
+
+    [Fact]
+    public async Task Lease_Increments_And_Release_Decrements_Active()
+    {
+        using var pool = CreatePool(new UnboundedPoolOptions { MinSize = 0, MaxIdle = 4 });
+        var ct = TestContext.Current.CancellationToken;
+
+        Assert.Equal(0, pool.ActiveLeases);
+        var item = await pool.LeaseAsync(ct);
+        Assert.Equal(1, pool.ActiveLeases);
+
+        pool.Release(item);
+        Assert.Equal(0, pool.ActiveLeases);
+    }
+
+    [Fact]
+    public async Task Release_Under_Cap_Retains_For_Reuse()
+    {
+        using var pool = CreatePool(new UnboundedPoolOptions { MinSize = 0, MaxIdle = 4 });
+        var ct = TestContext.Current.CancellationToken;
+
+        var item = await pool.LeaseAsync(ct);
+        pool.Release(item);
+        Assert.Equal(1, pool.ItemsAvailable);
+
+        // a retained item is reused rather than re-created
+        var reused = await pool.LeaseAsync(ct);
+        Assert.Same(item, reused);
+        Assert.False(reused.IsDisposed());
+
+        pool.Release(reused);
+    }
+
+    [Fact]
+    public async Task Release_Over_Cap_Drops_And_Disposes_The_Overflow()
+    {
+        // MaxIdle 1: the first return is retained, the second overflows the cap and is dropped+disposed
+        using var pool = CreatePool(new UnboundedPoolOptions { MinSize = 0, MaxIdle = 1 });
+        var ct = TestContext.Current.CancellationToken;
+
+        var first = await pool.LeaseAsync(ct);
+        var second = await pool.LeaseAsync(ct);
+
+        pool.Release(first);
+        Assert.Equal(1, pool.ItemsAvailable);
+        Assert.False(first.IsDisposed());
+
+        pool.Release(second);
+        // cap held: the overflow item was disposed, not pooled
+        Assert.Equal(1, pool.ItemsAvailable);
+        Assert.True(second.IsDisposed());
+        Assert.False(first.IsDisposed());
+    }
+
+    [Fact]
+    public async Task MaxIdle_Zero_Drops_Every_Return()
+    {
+        // pure allocate-on-lease: nothing is ever retained, every returned item is disposed
+        using var pool = CreatePool(new UnboundedPoolOptions { MinSize = 0, MaxIdle = 0 });
+        var ct = TestContext.Current.CancellationToken;
+
+        var item = await pool.LeaseAsync(ct);
+        pool.Release(item);
+
+        Assert.Equal(0, pool.ItemsAvailable);
+        Assert.True(item.IsDisposed());
+    }
+
+    [Fact]
+    public async Task Idle_Item_Past_Timeout_Is_Disposed_And_Fresh_One_Served()
+    {
+        // a controllable clock makes idle expiry deterministic: no Task.Delay, no wall-clock race
+        var timeProvider = new FakeTimeProvider();
+        using var pool = CreatePool(
+            new UnboundedPoolOptions { MinSize = 0, MaxIdle = 4, IdleTimeout = TimeSpan.FromMinutes(5) },
+            timeProvider: timeProvider);
+        var ct = TestContext.Current.CancellationToken;
+
+        var instance = await pool.LeaseAsync(ct);
+        pool.Release(instance);
+
+        // push the clock past the idle timeout; the next lease evicts (disposes) the stale item and serves fresh
+        timeProvider.Advance(TimeSpan.FromMinutes(6));
+        var fresh = await pool.LeaseAsync(ct);
+
+        Assert.True(instance.IsDisposed());
+        Assert.NotSame(instance, fresh);
+
+        pool.Release(fresh);
+    }
+
+    [Fact]
+    public async Task Unreleased_Lease_Stays_Outstanding_And_Is_Owned_By_The_Caller()
+    {
+        // ownership-transfer semantics: a leased item the caller never returns stays counted as
+        // outstanding, and the pool does not dispose it on its own disposal — the caller owns it
+        var pool = CreatePool(new UnboundedPoolOptions { MinSize = 0, MaxIdle = 4 });
+        var ct = TestContext.Current.CancellationToken;
+
+        var item = await pool.LeaseAsync(ct);
+        Assert.Equal(1, pool.ActiveLeases);
+
+        // leasing more is unaffected by the un-returned item (no capacity to starve)
+        var another = await pool.LeaseAsync(ct);
+        Assert.Equal(2, pool.ActiveLeases);
+        pool.Release(another);
+
+        pool.Dispose();
+
+        // the pool disposes only idle items; the outstanding leased item belongs to the caller
+        Assert.False(item.IsDisposed());
+        item.Dispose();
+    }
+
+    [Fact]
+    public async Task Preparation_Failure_Discards_Item_And_Does_Not_Count_The_Lease()
+    {
+        var preparationStrategy = new ThrowOnceEchoPreparationStrategy();
+        using var pool = CreatePool(
+            new UnboundedPoolOptions { MinSize = 0, MaxIdle = 4 },
+            preparationStrategy: preparationStrategy);
+        var ct = TestContext.Current.CancellationToken;
+
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(async () => await pool.LeaseAsync(ct));
+
+        // the broken item was disposed, the lease was never counted, and nothing was pooled
+        Assert.NotNull(preparationStrategy.FailedItem);
+        Assert.True(preparationStrategy.FailedItem!.IsDisposed());
+        Assert.Equal(0, pool.ActiveLeases);
+        Assert.Equal(0, pool.ItemsAllocated);
+
+        // the caller can retry and get a fresh, prepared item
+        var fresh = await pool.LeaseAsync(ct);
+        Assert.NotSame(preparationStrategy.FailedItem, fresh);
+        Assert.True(fresh.IsConnected);
+        pool.Release(fresh);
+    }
+
+    [Fact]
+    public async Task Preparation_Runs_Once_And_Is_Skipped_For_Reused_Item()
+    {
+        var preparationStrategy = new CountingEchoPreparationStrategy();
+        using var pool = CreatePool(
+            new UnboundedPoolOptions { MinSize = 0, MaxIdle = 4 },
+            preparationStrategy: preparationStrategy);
+        var ct = TestContext.Current.CancellationToken;
+
+        var instance = await pool.LeaseAsync(ct);
+        Assert.Equal(1, preparationStrategy.PrepareCount);
+        Assert.True(instance.IsConnected);
+
+        pool.Release(instance);
+        var reused = await pool.LeaseAsync(ct);
+        Assert.Same(instance, reused);
+        Assert.Equal(1, preparationStrategy.PrepareCount);
+
+        pool.Release(reused);
+    }
+
+    [Fact]
+    public void Seed_Respects_MaxIdle()
+    {
+        // MinSize beyond MaxIdle is clamped so the pool never starts over its own retention cap
+        using var pool = CreatePool(new UnboundedPoolOptions { MinSize = 5, MaxIdle = 2 });
+        Assert.Equal(2, pool.ItemsAvailable);
+        Assert.Equal(2, pool.ItemsAllocated);
+    }
+
+    [Fact]
+    public async Task Clear_Disposes_Idle_Items_And_Refills_With_Fresh_Ones()
+    {
+        using var pool = CreatePool(new UnboundedPoolOptions { MinSize = 2, MaxIdle = 4 });
+        var ct = TestContext.Current.CancellationToken;
+
+        var first = await pool.LeaseAsync(ct);
+        var second = await pool.LeaseAsync(ct);
+        pool.Release(first);
+        pool.Release(second);
+        Assert.Equal(2, pool.ItemsAvailable);
+
+        pool.Clear();
+
+        Assert.True(first.IsDisposed());
+        Assert.True(second.IsDisposed());
+        Assert.Equal(2, pool.ItemsAvailable);
+        Assert.Equal(2, pool.ItemsAllocated);
+
+        var fresh = await pool.LeaseAsync(ct);
+        Assert.NotSame(first, fresh);
+        Assert.NotSame(second, fresh);
+        Assert.False(fresh.IsDisposed());
+        pool.Release(fresh);
+    }
+
+    [Fact]
+    public async Task Dispose_Disposes_Idle_Items_Only()
+    {
+        var pool = CreatePool(new UnboundedPoolOptions { MinSize = 0, MaxIdle = 4 });
+        var ct = TestContext.Current.CancellationToken;
+
+        // hold two distinct items at once, then return one so a known instance sits idle while the
+        // other stays leased — otherwise releasing and re-leasing would just reuse the same instance
+        var idle = await pool.LeaseAsync(ct);
+        var leased = await pool.LeaseAsync(ct);
+        pool.Release(idle); // becomes idle, owned by the pool; leased stays out, owned by the caller
+
+        pool.Dispose();
+
+        Assert.True(idle.IsDisposed());
+        Assert.False(leased.IsDisposed());
+        leased.Dispose();
+    }
+
+    [Fact]
+    [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP013:Await in using", Justification = "it's not")]
+    [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP016:Don't use disposed instance", Justification = "the test deliberately exercises post-dispose rejection")]
+    [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP017:Prefer using", Justification = "the test deliberately calls Dispose to verify idempotency and post-dispose rejection")]
+    public async Task Disposed_Pool_Rejects_Operations_And_Tolerates_Double_Dispose()
+    {
+        var pool = CreatePool(new UnboundedPoolOptions { MinSize = 1, MaxIdle = 4 });
+        var item = await pool.LeaseAsync(TestContext.Current.CancellationToken);
+
+        pool.Dispose();
+        pool.Dispose(); // idempotent
+
+        _ = Assert.Throws<ObjectDisposedException>(() => pool.Release(item));
+        _ = Assert.Throws<ObjectDisposedException>(pool.Clear);
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(
+            async () => await pool.LeaseAsync(TestContext.Current.CancellationToken));
+
+        item.Dispose();
+    }
+
+    [Fact]
+    public void Release_Null_Throws()
+    {
+        using var pool = CreatePool(new UnboundedPoolOptions());
+        _ = Assert.Throws<ArgumentNullException>(() => pool.Release(null!));
+    }
+
+    [Fact]
+    public async Task Ctor_Without_Preparation_Strategy_Skips_Preparation()
+    {
+        // exercises the prep-less constructor overload: items are handed out without a readiness step
+        using var pool = new UnboundedPool<IEcho>(new EchoFactory(), Logger, Metrics, new UnboundedPoolOptions { MinSize = 0, MaxIdle = 4 });
+
+        var item = await pool.LeaseAsync(TestContext.Current.CancellationToken);
+        Assert.NotNull(item);
+        Assert.False(item.IsConnected); // no preparation strategy ran
+        pool.Release(item);
+    }
+
+    [Fact]
+    [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP005:Return type should indicate that the value should be disposed", Justification = "each constructor guard clause throws before construction completes, so no instance exists to dispose")]
+    public void Ctor_Null_Arguments_Throw()
+    {
+        _ = Assert.Throws<ArgumentNullException>(
+            () => new UnboundedPool<IEcho>(null!, Logger, Metrics, new UnboundedPoolOptions()));
+        _ = Assert.Throws<ArgumentNullException>(
+            () => new UnboundedPool<IEcho>(new EchoFactory(), null!, Metrics, new UnboundedPoolOptions()));
+        _ = Assert.Throws<ArgumentNullException>(
+            () => new UnboundedPool<IEcho>(new EchoFactory(), Logger, null!, new UnboundedPoolOptions()));
+        _ = Assert.Throws<ArgumentNullException>(
+            () => new UnboundedPool<IEcho>(new EchoFactory(), Logger, Metrics, (UnboundedPoolOptions)null!));
+    }
+
+    [Fact]
+    public void Ctor_Negative_MinSize_Throws() =>
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => CreatePool(new UnboundedPoolOptions { MinSize = -1 }));
+
+    [Fact]
+    public void Ctor_Negative_MaxIdle_Throws() =>
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => CreatePool(new UnboundedPoolOptions { MaxIdle = -1 }));
+
+    [Fact]
+    public void Ctor_Factory_Failure_Mid_Seed_Disposes_Already_Created_Items()
+    {
+        // the seeded items created before the failure must be disposed, leaving no leak behind
+        var factory = new ThrowAfterCountItemFactory(throwAfter: 2);
+
+        _ = Assert.Throws<InvalidOperationException>(
+            () => CreatePool(new UnboundedPoolOptions { MinSize = 5, MaxIdle = 10 }, factory));
+
+        Assert.Equal(2, factory.CreatedItems.Count);
+        Assert.All(factory.CreatedItems, echo => Assert.True(echo.IsDisposed()));
+    }
+
+    [Fact]
+    public async Task Already_Cancelled_Token_Cancels_The_Lease()
+    {
+        using var pool = CreatePool(new UnboundedPoolOptions { MinSize = 0, MaxIdle = 4 });
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await pool.LeaseAsync(cts.Token));
+        Assert.Equal(0, pool.ActiveLeases);
+    }
+
+    [Fact]
+    public async Task LeaseScope_Returns_Item_On_Dispose()
+    {
+        using var pool = CreatePool(new UnboundedPoolOptions { MinSize = 0, MaxIdle = 4 });
+        var ct = TestContext.Current.CancellationToken;
+
+        IEcho leased;
+        using (var lease = await pool.LeaseScopeAsync(ct))
+        {
+            leased = lease.Item;
+            Assert.Equal(1, pool.ActiveLeases);
+        }
+
+        // disposing the scope returned the item to the pool for reuse
+        Assert.Equal(0, pool.ActiveLeases);
+        Assert.Equal(1, pool.ItemsAvailable);
+        Assert.False(leased.IsDisposed());
+    }
+
+    [Fact]
+    [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP013:Await in using", Justification = "it's not")]
+    public async Task Concurrent_Churn_Never_Aliases_And_Respects_Idle_Cap()
+    {
+        const int maxIdle = 8;
+        using var pool = CreatePool(new UnboundedPoolOptions { MinSize = 0, MaxIdle = maxIdle });
+
+        var held = new ConcurrentDictionary<IEcho, byte>();
+        var doubleHandouts = 0;
+        var capViolations = 0;
+        var ct = TestContext.Current.CancellationToken;
+
+        await Parallel.ForEachAsync(
+            Enumerable.Range(0, 5_000),
+            new ParallelOptions { MaxDegreeOfParallelism = 16, CancellationToken = ct },
+            async (i, token) =>
+            {
+                var item = await pool.LeaseAsync(token);
+                if (!held.TryAdd(item, 0))
+                {
+                    _ = Interlocked.Increment(ref doubleHandouts);
+                }
+
+                if (pool.ItemsAvailable > maxIdle)
+                {
+                    _ = Interlocked.Increment(ref capViolations);
+                }
+
+                Thread.SpinWait(200);
+                _ = held.TryRemove(item, out _);
+                pool.Release(item);
+            });
+
+        Assert.Equal(0, doubleHandouts);
+        Assert.Equal(0, capViolations);
+        Assert.Equal(0, pool.ActiveLeases);
+        Assert.True(pool.ItemsAvailable <= maxIdle);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `UnboundedPool<TPoolItem> : IPool<TPoolItem>`, an unbounded counterpart to the bounded `Pool<T>`, modeled on `System.Buffers.ArrayPool<T>`. Same interface, factory, preparation strategy, and metrics — different capacity contract.

The key semantic shift: the bounded pool is a **borrow** (the pool retains title; a lease must be returned), while the unbounded pool is an **ownership transfer** (a lease hands the item to the caller). That distinction is what makes optional release safe even for `IDisposable` items.

## Behavior

- **Lease never waits** — returns an idle item or creates one on demand. No capacity gate, so `QueuedLeases` is always `0`.
- **Release is optional** — a donation back for reuse, not an obligation. A never-returned item is simply not reused; disposing it (if needed) is the caller's responsibility, exactly as for any object they own.
- **Bounded retention** — `UnboundedPoolOptions.MaxIdle` caps the idle store. Returns over the cap are dropped and disposed (drop-on-full); expired-idle items are dropped and disposed on lease. The pool disposes only the idle items it still holds — leased-out items belong to their callers.
- **Honest counters** — `ActiveLeases = handed-out − returned` via one `Interlocked` counter, so an item a caller dropped without returning stays counted as outstanding (it genuinely is). `Name` = `"{T}.UnboundedPool"`.

## Options

`UnboundedPoolOptions` exposes only the knobs the pool honors — `MinSize`, `MaxIdle`, `IdleTimeout`, `PreparationTimeout`, and the default factory/strategy flags. No `MaxSize` or `LeaseTimeout`, so the bounded-only controls can't be misconfigured.

## DI

Registration parallels the bounded pool and reuses the existing `IPoolFactory<T>` unchanged:

- `AddUnboundedPool<TPoolItem>(configuration, configureOptions?)`
- `AddNamedUnboundedPool<TPoolItem>(name, configuration, configureOptions?)`
- `AddUnboundedPool<TPoolItem, TClient>(...)` (named pool + typed client)
- `AddDefaultUnboundedPoolMetrics<TPoolItem>(...)`

## Tests & verification

- **144 tests pass** (31 new), covering never-wait rent, retain-under-cap, drop-on-full, expired-idle eviction, ownership-transfer/optional-release, `Clear`, idle-only disposal, `LeaseScopeAsync`, concurrency (no aliasing, cap respected), ctor guards, and the full DI surface (including named registration).
- **Coverage 99.32 / 92.44 / 95.31** (line/branch/method), clearing the 95/90/95 gate.
- Full solution Release build: 0 warnings, 0 errors (TreatWarningsAsErrors on).

## Notes / follow-ups (not in this PR)

- The item-store / preparation / metrics logic is intentionally duplicated from `Pool<T>` for now; extracting a shared component is a planned follow-up.
- Includes a design note for a future bounded-pool **hold-timeout slot-reclaim** feature (`docs/notes/hold-timeout-reclaims-the-slot-not-the-item.md`); not implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)